### PR TITLE
Fix dashboard layout: remove scrollbars and fit calendar

### DIFF
--- a/client/components/Dashboard.tsx
+++ b/client/components/Dashboard.tsx
@@ -140,7 +140,7 @@ export function Dashboard({ className }: DashboardProps) {
         </aside>
 
         {/* Main Content */}
-        <main className="flex-1 overflow-auto bg-dashboard-content">
+        <main className="flex-1 bg-dashboard-content">
           <div className="p-4 md:p-6">
             {activeView === "calendar" && (
               <div className="space-y-4 md:space-y-6">

--- a/client/components/Dashboard.tsx
+++ b/client/components/Dashboard.tsx
@@ -140,7 +140,7 @@ export function Dashboard({ className }: DashboardProps) {
         </aside>
 
         {/* Main Content */}
-        <main className="flex-1 bg-dashboard-content">
+        <main className="flex-1 bg-dashboard-content overflow-y-auto h-[calc(100vh-4rem)]">
           <div className="p-4 md:p-6">
             {activeView === "calendar" && (
               <div className="space-y-4 md:space-y-6">

--- a/client/components/Dashboard.tsx
+++ b/client/components/Dashboard.tsx
@@ -109,7 +109,7 @@ export function Dashboard({ className }: DashboardProps) {
           w-64 border-r border-border bg-dashboard-nav transition-transform duration-300 ease-in-out
           md:translate-x-0 md:static md:inset-0
           ${sidebarOpen ? "translate-x-0" : "-translate-x-full"}
-          fixed inset-y-0 left-0 z-50 md:z-auto
+          fixed inset-y-0 left-0 z-50 md:z-auto md:h-[calc(100vh-4rem)] md:overflow-y-auto
         `}
         >
           <div className="p-4 md:p-6">

--- a/client/components/PetCareCalendar.tsx
+++ b/client/components/PetCareCalendar.tsx
@@ -197,7 +197,7 @@ export function PetCareCalendar({
             {/* Time Grid */}
             <div className="space-y-2">
               {timeSlots.map((time) => (
-                <div key={time} className="grid grid-cols-8 gap-2 min-h-[60px]">
+                <div key={time} className="grid grid-cols-8 gap-1 min-h-[50px] md:min-h-[60px]">
                   {/* Time Column */}
                   <div className="p-3 bg-timetable-cell rounded-lg flex items-center">
                     <span className="text-sm text-muted-foreground font-mono">

--- a/client/components/PetCareCalendar.tsx
+++ b/client/components/PetCareCalendar.tsx
@@ -258,7 +258,7 @@ export function PetCareCalendar({
                             </div>
                           </div>
                         ) : (
-                          <div className="p-3 bg-timetable-cell rounded-lg h-full min-h-[60px] border border-timetable-border hover:bg-accent/50 transition-colors cursor-pointer group">
+                          <div className="p-1 md:p-3 bg-timetable-cell rounded-lg h-full min-h-[50px] md:min-h-[60px] border border-timetable-border hover:bg-accent/50 transition-colors cursor-pointer group">
                             <div className="flex items-center justify-center h-full">
                               <span className="text-xs text-muted-foreground group-hover:text-foreground transition-colors">
                                 Free

--- a/client/components/PetCareCalendar.tsx
+++ b/client/components/PetCareCalendar.tsx
@@ -175,7 +175,7 @@ export function PetCareCalendar({
         <div className="overflow-x-auto">
           <div className="w-full">
             {/* Header */}
-            <div className="grid grid-cols-8 gap-1 md:gap-2 mb-4">
+            <div className="grid grid-cols-8 gap-1 mb-4">
               <div className="p-2 md:p-3 bg-timetable-header rounded-lg">
                 <span className="text-xs md:text-sm font-medium text-foreground">
                   Time

--- a/client/components/PetCareCalendar.tsx
+++ b/client/components/PetCareCalendar.tsx
@@ -199,8 +199,8 @@ export function PetCareCalendar({
               {timeSlots.map((time) => (
                 <div key={time} className="grid grid-cols-8 gap-1 min-h-[50px] md:min-h-[60px]">
                   {/* Time Column */}
-                  <div className="p-3 bg-timetable-cell rounded-lg flex items-center">
-                    <span className="text-sm text-muted-foreground font-mono">
+                  <div className="p-1 md:p-3 bg-timetable-cell rounded-lg flex items-center justify-center">
+                    <span className="text-xs md:text-sm text-muted-foreground font-mono">
                       {time}
                     </span>
                   </div>

--- a/client/components/PetCareCalendar.tsx
+++ b/client/components/PetCareCalendar.tsx
@@ -197,7 +197,10 @@ export function PetCareCalendar({
             {/* Time Grid */}
             <div className="space-y-2">
               {timeSlots.map((time) => (
-                <div key={time} className="grid grid-cols-8 gap-1 min-h-[50px] md:min-h-[60px]">
+                <div
+                  key={time}
+                  className="grid grid-cols-8 gap-1 min-h-[50px] md:min-h-[60px]"
+                >
                   {/* Time Column */}
                   <div className="p-1 md:p-3 bg-timetable-cell rounded-lg flex items-center justify-center">
                     <span className="text-xs md:text-sm text-muted-foreground font-mono">

--- a/client/components/PetCareCalendar.tsx
+++ b/client/components/PetCareCalendar.tsx
@@ -217,7 +217,7 @@ export function PetCareCalendar({
                         {eventAtTime ? (
                           <div
                             className={cn(
-                              "p-3 rounded-lg border h-full min-h-[60px] transition-all duration-200 hover:scale-105 hover:shadow-lg cursor-pointer",
+                              "p-1 md:p-3 rounded-lg border h-full min-h-[50px] md:min-h-[60px] transition-all duration-200 hover:scale-105 hover:shadow-lg cursor-pointer",
                               eventAtTime.color,
                             )}
                             onClick={() => handleEventClick(eventAtTime)}

--- a/client/components/PetCareCalendar.tsx
+++ b/client/components/PetCareCalendar.tsx
@@ -173,7 +173,7 @@ export function PetCareCalendar({
         </div>
 
         <div className="overflow-x-auto">
-          <div className="min-w-[1000px]">
+          <div className="w-full">
             {/* Header */}
             <div className="grid grid-cols-8 gap-1 md:gap-2 mb-4">
               <div className="p-2 md:p-3 bg-timetable-header rounded-lg">


### PR DESCRIPTION
## Purpose

This PR addresses several UI/UX improvements requested by users:
- Make the calendar component fit properly within the screen boundaries
- Remove additional scrollbars that were causing layout issues in the dashboard
- Keep the left navigation tabs fixed in position during scrolling

## Code changes

**Dashboard.tsx:**
- Added height constraints (`h-[calc(100vh-4rem)]`) and overflow handling to the sidebar and main content areas
- Changed main content overflow from `overflow-auto` to `overflow-y-auto` with explicit height to prevent double scrollbars
- Added responsive overflow behavior to the sidebar navigation

**PetCareCalendar.tsx:**
- Removed fixed minimum width (`min-w-[1000px]`) from calendar container to allow responsive fitting
- Reduced grid gaps and padding on mobile devices for better space utilization
- Adjusted minimum heights for time slots (50px on mobile, 60px on desktop)
- Made time column text and padding responsive to improve mobile layout
- Updated grid spacing to be more compact while maintaining readability

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/792e9400f6734fc49b895a73b9ecdfd7/pulse-field)

👀 [Preview Link](https://792e9400f6734fc49b895a73b9ecdfd7-pulse-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>792e9400f6734fc49b895a73b9ecdfd7</projectId>-->
<!--<branchName>pulse-field</branchName>-->